### PR TITLE
Fix html test

### DIFF
--- a/test/specs/compiler/html.js
+++ b/test/specs/compiler/html.js
@@ -47,7 +47,7 @@ describe('Compile HTML', function() {
   })
 
   it('option `whitespace` normalizes and preserves line endings', function() {
-    testStr('<p>a\r</p>\r\r\n<p>\n</p>', '<p>a\\n</p>\\n\\n<p>\\n</p>', { whitespace: 1 })
+    testStr('<p>a\r</p>\r\r\n<p>\n</p>', '<p>a\n</p>\n\n<p>\n</p>', { whitespace: 1 })
   })
 
   it('option `compact` removes line endings between tags', function() {


### PR DESCRIPTION
Please use `npm update riot-compiler`
riot-compiler v2.3.13 properly handles the preservation of newlines, but breaks the current test. This change fixes the issue.